### PR TITLE
Ensure that "Norway" is interpreted as string

### DIFF
--- a/db/fixtures/iso_countries.yml
+++ b/db/fixtures/iso_countries.yml
@@ -639,7 +639,7 @@ netherlands:
   name: Netherlands
 
 norway:
-  code: NO
+  code: 'NO'
   name: Norway
 
 nepal:


### PR DESCRIPTION
In yaml, no is parsed as a boolean type.

You have to wrap "NO" in quotes to get the expected result.
NI: Nicaragua
NL: Netherlands
NO: Norway # 💣!

See: https://noyaml.com/